### PR TITLE
Fix title parsing

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -82,7 +82,7 @@ parsed_html = BeautifulSoup(html, 'html5lib')
 urls = []
 lessons = []
 
-title = parsed_html.find('div', attrs={'class', 'course-title'}).find('span').text
+title = parsed_html.find('div', attrs={'class', 'course-title'}).find('h1').find(text=True, recursive=False)
 anchors = parsed_html.find_all('a', attrs={'class', 'syllabus-item'})
 
 for anchor in anchors:


### PR DESCRIPTION
Seems like Linux Academy have made HTML changes recently in courses main pages and there's no \<span> tag under the \<div> tag with `class="course-title"`, here's an example:
```
<div class="course-title"><h1><strong>Course: </strong>LPIC-3 Exam 303: Security </h1></div>
```

This breaks the tool ass the `driver.py` will exit with a 'NoneType' if we don't update the line where the title parsing happens.